### PR TITLE
Update the pgp keyserver to a more reliable server

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:jessie-curl
 
 RUN gpg \
-    --keyserver hkp://pgp.mit.edu \
+    --keyserver hkp://ha.pool.sks-keyservers.net \
     --recv-keys 05CE15085FC09D18E99EFB22684A14CF2582E0C5
 
 ENV INFLUXDB_VERSION 0.10.3

--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:jessie-curl
 
 RUN gpg \
-    --keyserver hkp://pgp.mit.edu \
+    --keyserver hkp://ha.pool.sks-keyservers.net \
     --recv-keys 05CE15085FC09D18E99EFB22684A14CF2582E0C5
 
 ENV INFLUXDB_VERSION 0.11.1

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:jessie-curl
 
 RUN gpg \
-    --keyserver hkp://pgp.mit.edu \
+    --keyserver hkp://ha.pool.sks-keyservers.net \
     --recv-keys 05CE15085FC09D18E99EFB22684A14CF2582E0C5
 
 ENV INFLUXDB_VERSION 0.12.0


### PR DESCRIPTION
Suggested here:
https://github.com/docker-library/official-images/pull/1583#issuecomment-206596000