### PR TITLE
Move -config to entrypoint.sh so we can emulate 0.13

### DIFF
--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -18,4 +18,4 @@ VOLUME /var/lib/influxdb
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["influxd", "-config", "/etc/influxdb/influxdb.conf"]
+CMD ["influxd"]

--- a/0.12/entrypoint.sh
+++ b/0.12/entrypoint.sh
@@ -2,7 +2,13 @@
 set -e
 
 if [ "${1:0:1}" = '-' ]; then
-	set -- influxd "$@"
+    set -- influxd "$@"
+fi
+
+# TODO remove this for 0.13
+if [ "$1" = 'influxd' ]; then
+    shift
+    set -- influxd -config /etc/influxdb/influxdb.conf "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
This emulates what 0.13 will be doing with some simple tricks in `entrypoint.sh` (https://github.com/docker-library/official-images/pull/1583#issuecomment-213602816); if `-config` is specified on the command line separately, the last one wins (and I tested that it appropriately overrides the default with this code). :+1:

See also https://github.com/influxdata/telegraf-docker/pull/12