### PR TITLE
alpine: Update to 3.4

### DIFF
--- a/0.13/alpine/Dockerfile
+++ b/0.13/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 ENV INFLUXDB_VERSION 0.13.0
 RUN apk add --no-cache --virtual .build-deps wget gnupg tar ca-certificates && \

--- a/nightly/alpine/Dockerfile
+++ b/nightly/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 RUN apk add --no-cache --virtual .build-deps wget gnupg tar ca-certificates && \
     update-ca-certificates && \


### PR DESCRIPTION
I just tested compiling and testing influxdb on alpine 3.4. I've yet to find a good way of testing the glibc-compiled version on alpine so I'm open for tips/suggestions.